### PR TITLE
chore: add release-please for automated releases

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -1,0 +1,18 @@
+name: Release Please
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release-please:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: googleapis/release-please-action@v4
+        with:
+          config-file: .release-please-config.json
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.release-please-config.json
+++ b/.release-please-config.json
@@ -1,0 +1,66 @@
+{
+  "packages": {
+    ".": {
+      "changelog-path": "CHANGELOG.md",
+      "release-type": "node",
+      "bump-minor-pre-major": true,
+      "bump-patch-for-minor-pre-major": true,
+      "include-component-in-tag": false,
+      "draft": false,
+      "prerelease": false,
+      "changelog-sections": [
+        {
+          "type": "feat",
+          "section": "### Added",
+          "hidden": false
+        },
+        {
+          "type": "fix",
+          "section": "### Fixed",
+          "hidden": false
+        },
+        {
+          "type": "perf",
+          "section": "### Improved",
+          "hidden": false
+        },
+        {
+          "type": "docs",
+          "section": "### Documentation",
+          "hidden": false
+        },
+        {
+          "type": "style",
+          "section": "### Style",
+          "hidden": false
+        },
+        {
+          "type": "refactor",
+          "section": "### Refactor",
+          "hidden": false
+        },
+        {
+          "type": "test",
+          "section": "### Test",
+          "hidden": false
+        },
+        {
+          "type": "build",
+          "section": "### Build",
+          "hidden": false
+        },
+        {
+          "type": "ci",
+          "section": "### CI",
+          "hidden": false
+        },
+        {
+          "type": "chore",
+          "section": "### Chore",
+          "hidden": false
+        }
+      ]
+    }
+  },
+  "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json"
+}

--- a/README.md
+++ b/README.md
@@ -207,6 +207,44 @@ Feel free to open issues or PRs on the [GitHub repository](https://github.com/th
 
 ## Development
 
+### Automated Releases
+
+This project uses [release-please](https://github.com/googleapis/release-please) for automated semantic versioning and release management.
+
+#### How it works:
+
+1. **Conventional Commits**: All commits should follow the [Conventional Commits](https://www.conventionalcommits.org/) specification:
+
+   - `feat:` for new features (minor version bump)
+   - `fix:` for bug fixes (patch version bump)
+   - `feat!:` or `fix!:` for breaking changes (major version bump)
+   - `docs:`, `style:`, `refactor:`, `perf:`, `test:`, `chore:` for other changes
+
+2. **Automated Release Process**:
+
+   - When commits are pushed to the `main` branch, release-please analyzes the commit messages
+   - It automatically determines the next version number based on semantic versioning
+   - Creates a pull request with updated version and changelog
+   - When the PR is merged, it creates a GitHub release
+   - The release triggers automatic publishing to the VS Code Marketplace
+
+3. **Commit Message Examples**:
+   ```bash
+   feat: add new filter validation feature
+   fix: resolve color preview display issue
+   feat!: breaking change in filter syntax
+   docs: update README with new features
+   ```
+
+#### Manual Release
+
+To create a release manually:
+
+1. Create a commit with a conventional commit message
+2. Push to the `main` branch
+3. Release-please will create a PR automatically
+4. Review and merge the PR to create the release
+
 ### Building and Packaging
 
 To create a .vsix package:


### PR DESCRIPTION
Configure release-please with semantic versioning and changelog
sections to automate release management. Add GitHub Actions workflow
to trigger release-please on pushes to main branch. Update README with
instructions on commit conventions and release process to improve
developer experience and ensure consistent versioning.