### PR TITLE
ci: add GitHub Actions workflow to publish extension

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -1,0 +1,36 @@
+name: Publish Extension
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 9.5.0
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build extension
+        run: pnpm run build
+
+      - name: Package extension
+        run: pnpm run package
+
+      - name: Publish to VS Code Marketplace
+        run: pnpm run vsce:publish
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}


### PR DESCRIPTION
Add a workflow triggered on release publication to automate the
process of building, packaging, and publishing the VS Code extension.
This ensures consistent and streamlined releases to the Marketplace.