### PR TITLE
chore(ci): remove fixed pnpm version from workflow

### DIFF
--- a/.github/workflows/update-data.yml
+++ b/.github/workflows/update-data.yml
@@ -24,8 +24,6 @@ jobs:
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
-        with:
-          version: 9.5.0
 
       - name: Install dependencies
         run: pnpm install


### PR DESCRIPTION
Remove the explicit pnpm version 9.5.0 from the setup step in the
update-data workflow to allow using the latest compatible version.
This change simplifies maintenance and ensures the workflow uses
up-to-date tooling without manual updates.