### PR TITLE
ci: trigger extension publish on release created event

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -2,7 +2,7 @@ name: Publish Extension
 
 on:
   release:
-    types: [published]
+    types: [published, created]
 
 jobs:
   publish:


### PR DESCRIPTION
Update GitHub Actions workflow to trigger the publish job not only
when a release is published but also when it is created. This ensures
the extension is published promptly on both release creation and
publication events, improving deployment responsiveness.