### PR TITLE
fix(ci): exit process if no new version is available

### DIFF
--- a/scripts/update-data.ts
+++ b/scripts/update-data.ts
@@ -47,6 +47,7 @@ async function updateData() {
       console.log(`Config updated to version: ${currentVersion}`);
     } else {
       console.log("No new version available.");
+      process.exit();
     }
 
     // Run data synchronization


### PR DESCRIPTION
Add process.exit() to stop execution when no new version is found.
This prevents unnecessary data synchronization and improves script
efficiency.