### PR TITLE
feat: support "!" and "!=" not-equal operators

### DIFF
--- a/examples/issue-125-op-filter.filter
+++ b/examples/issue-125-op-filter.filter
@@ -1,0 +1,258 @@
+###################################################### TEST #########################################################
+
+###### Visuals ######################################################################################################
+
+###### Rarity Items ##################
+
+# Unique
+Show
+    Rarity Unique
+    MinimapIcon 1 Orange Circle
+    SetTextColor 200 100 0
+    SetBorderColor 200 100 0
+    SetBackgroundColor 200 100 0 120
+    Continue
+
+# Rare
+Show
+    Rarity Rare
+    MinimapIcon 1 Yellow Circle
+    SetTextColor 240 200 40
+    SetBorderColor 240 200 40
+    SetBackgroundColor 240 200 40 120
+    Continue
+
+# Magic
+Show 
+    Rarity Magic
+    MinimapIcon 1 Blue Circle
+    SetTextColor 80 120 200
+    SetBorderColor 80 120 200
+    SetBackgroundColor 80 120 200 120
+    Continue
+
+# Normal
+Show 
+    Rarity Normal
+    MinimapIcon 1 White Circle
+    SetTextColor 200 200 200
+    SetBorderColor 200 200 200
+    SetBackgroundColor 200 200 200 120
+    Continue
+
+###### Non Rarity Items ##################
+
+# General
+Show
+    Class "Currency" "Gem" "Augment" "Trial" "Ultimatum"
+    MinimapIcon 1 Green Circle
+    SetTextColor 140 120 100
+    SetBorderColor 140 120 100
+    SetBackgroundColor 140 120 100 120
+    Continue
+
+# Quest
+Show
+    Class "Quest Item"
+    MinimapIcon 1 Purple Circle
+    SetTextColor 120 40 200
+    SetBorderColor 120 40 200
+    SetBackgroundColor 120 40 200 120
+    Continue
+
+###### Logic ########################################################################################################
+
+###### Normal Items Logic ##################
+
+# General
+#Show
+#    Rarity Normal
+#    Sockets > 0
+Show
+    Rarity Normal
+    Quality > 0
+Hide
+    Rarity Normal
+    Class "Flask"
+Hide
+    Rarity Normal
+    Class "Ring" 
+    BaseType ! "Prismatic" "Amethyst" "Topaz" "Sapphire" "Ruby"
+Hide
+    Rarity Normal
+    Class "Amulet"
+    BaseType ! "Jade" "Lapis" "Amber"
+Hide
+    Rarity Normal
+    Class "Belt"
+
+# Weapons
+Hide
+    Rarity Normal
+    Class "Claw" "Crossbow" "Spear" "Dagger" "Hand" "Stave" "Wand" "Shield" "Buckler" "Focus" "Sceptre" "Talisman"
+Hide
+    Rarity Normal
+    Class "Bows"
+    DropLevel < 67
+Hide
+    Rarity Normal
+    Class "Quiver"
+
+# Armor
+Show
+    Rarity Normal
+    Class "Body Armour" "Gloves" "Boots" "Helmet"
+    AreaLevel <= 5
+Show
+    Rarity Normal
+    Class "Body Armour" "Gloves" "Boots"
+    DropLevel > 54
+    AreaLevel < 65
+    BaseEnergyShield == 0
+    BaseArmour == 0
+Show
+    Rarity Normal
+    Class "Helmet"
+    DropLevel > 54
+    AreaLevel < 65
+    BaseArmour == 0
+Show
+    Rarity Normal
+    Class "Body Armour" "Gloves" "Boots"
+    AreaLevel >= 65
+    DropLevel >= 65
+    BaseEnergyShield == 0
+    BaseArmour == 0
+Show
+    Rarity Normal
+    Class "Helmet"
+    DropLevel >= 65
+    AreaLevel >= 65
+    BaseArmour == 0
+Hide
+    Rarity Normal
+    Class "Body Armour" "Gloves" "Boots" "Helmet"
+
+###### Magic Items Logic ##################
+
+# General
+#Show
+#    Rarity Magic
+#    Sockets > 0
+Show
+    Rarity Magic
+    Quality > 0
+Hide
+    Rarity Magic
+    Class "Flask"
+    AreaLevel > 65
+    DropLevel < 60
+Hide
+    Rarity Magic
+    Class "Ring" 
+    BaseType ! "Prismatic" "Amethyst" "Topaz" "Sapphire" "Ruby"
+
+# Weapons
+Hide
+    Rarity Magic
+    Class "Claw" "Crossbow" "Spear" "Dagger" "Hand" "Stave" "Wand" "Shield" "Buckler" "Focus" "Sceptre" "Talisman"
+Hide
+    Rarity Magic
+    Class "Bow"
+    DropLevel < 67
+Hide
+    Rarity Magic
+    Class "Quiver"
+
+# Armor
+Show
+    Rarity Magic
+    Class "Body Armour" "Gloves" "Boots" "Helmet"
+    AreaLevel <= 15
+Show
+    Rarity Magic
+    Class "Body Armour" "Gloves" "Boots"
+    DropLevel > 54
+    AreaLevel < 65
+    BaseEnergyShield == 0
+    BaseArmour == 0
+Show
+    Rarity Magic
+    Class "Helmet"
+    DropLevel > 54
+    AreaLevel < 65
+    BaseArmour == 0
+Show
+    Rarity Magic
+    Class "Body Armour" "Gloves" "Boots"
+    AreaLevel >= 65
+    DropLevel >= 65
+    BaseEnergyShield == 0
+    BaseArmour == 0
+Show
+    Rarity Magic
+    Class "Helmet"
+    DropLevel >= 65
+    AreaLevel >= 65
+    BaseArmour == 0
+Hide
+    Rarity Magic
+    Class "Body Armour" "Gloves" "Boots" "Helmet"
+
+###### Rare Items Logic ##################
+
+# General
+#Show
+#    Rarity Rare
+#    Sockets > 0
+Show
+    Rarity Rare
+    Quality > 0
+
+# Weapons
+Hide
+    Rarity Rare
+    Class "Claw" "Dagger" "Hand" "Wand" "Shield" "Buckler" "Focus" "Sceptre"
+Hide
+    Rarity Rare
+    Class "Crossbow" "Spear" "Quarterstave"
+    DropLevel < 67
+Hide
+    Rarity Rare
+    Class "Talisman"
+    DropLevel < 65
+Hide
+    Rarity Rare
+    Class "Bow"
+    DropLevel < 67
+
+# Armor
+Show
+    Rarity Rare
+    Class "Body Armour" "Gloves" "Boots" "Helmet"
+    AreaLevel <= 32
+Show
+    Rarity Rare
+    Class "Body Armour" "Gloves" "Boots"
+    BaseEnergyShield == 0
+    BaseArmour == 0
+    AreaLevel <= 53
+Show
+    Rarity Rare
+    Class "Helmet"
+    BaseEvasion == 0
+    BaseArmour == 0
+    AreaLevel <= 53
+Show
+    Rarity Rare
+    Class "Body Armour" "Gloves" "Boots" "Helmet"
+    DropLevel >= 54
+    AreaLevel >= 54
+Show
+    Rarity Rare
+    Class "Body Armour" "Gloves" "Boots" "Helmet"
+    AreaLevel >= 65
+    DropLevel >= 65
+Hide
+    Rarity Rare
+    Class "Body Armour" "Gloves" "Boots" "Helmet"

--- a/examples/not-equal-operators.filter
+++ b/examples/not-equal-operators.filter
@@ -1,0 +1,106 @@
+# Not-Equal Operator Test Filter (issue #125)
+# Demonstrates the "!" and "!=" operators (both mean "not equal").
+#
+# Tuned for LOW-LEVEL characters (Act 1): every rule targets items you see
+# constantly while leveling and paints them a DISTINCT colour + minimap icon
+# + light beam, so you can instantly tell which rule caught a drop.
+#
+# What to check:
+#   - No line below is flagged as a syntax error / "Unknown command" /
+#     "Invalid value for operator", and "!" / "!=" highlight as operators.
+#   - In game, drops are coloured by the rules below. If "!=" / "!" works,
+#     the non-equal rules catch everything EXCEPT the excluded value.
+
+#--------------------------------
+# Positive control (exact match) - WHITE text on GREEN
+# Scroll of Wisdom should look different from every other currency below.
+#--------------------------------
+Show
+    BaseType == "Scroll of Wisdom"
+    SetFontSize 45
+    SetTextColor 255 255 255 255
+    SetBackgroundColor 0 90 0 255
+    MinimapIcon 0 Green Circle
+    PlayEffect Green
+
+#--------------------------------
+# "!=" on BaseType - CYAN
+# Any currency that is NOT a Scroll of Wisdom.
+#--------------------------------
+Show
+    Class "Currency"
+    BaseType != "Scroll of Wisdom"
+    SetFontSize 40
+    SetTextColor 0 0 0 255
+    SetBackgroundColor 0 200 220 255
+    MinimapIcon 1 Cyan Diamond
+    PlayEffect Cyan
+
+#--------------------------------
+# "!=" on Rarity - BLUE
+# Flasks that are NOT Unique (i.e. Normal/Magic - all the ones you find early).
+#--------------------------------
+Show
+    Class "Flask"
+    Rarity != Unique
+    SetFontSize 38
+    SetTextColor 255 255 255 255
+    SetBackgroundColor 0 0 160 255
+    MinimapIcon 1 Blue Square
+    PlayEffect Blue
+
+#--------------------------------
+# "!" short form on Rarity - YELLOW
+# Weapons/armour that are NOT Normal (Magic or better) get a bright border.
+#--------------------------------
+Show
+    Class "Wands" "Sceptres" "Body Armours"
+    Rarity ! Normal
+    SetFontSize 40
+    SetTextColor 255 255 0 255
+    SetBorderColor 255 255 0 255
+    MinimapIcon 0 Yellow Star
+    PlayEffect Yellow
+
+#--------------------------------
+# "!=" on a numeric condition - ORANGE border
+# Uncut Skill Gems whose level is NOT 1 (drops scale with area while leveling).
+#--------------------------------
+Show
+    Class "Uncut Skill Gems"
+    ItemLevel != 1
+    SetFontSize 40
+    SetTextColor 255 160 0 255
+    SetBorderColor 255 160 0 255
+    MinimapIcon 0 Orange Triangle
+    PlayEffect Orange
+
+#--------------------------------
+# Enum not-equal test (Rarity) - GREEN vs GREY
+# The "!=" rule is intentionally FIRST so a broken not-equal is obvious:
+#   - Works:  Magic/Rare/Unique = green, Normal = grey (clean split).
+#   - Broken: Normal items ALSO turn green (rule 1 wrongly catches them).
+# Swap "Normal" for Unique/Magic/Rare to test each enum value.
+#--------------------------------
+Show
+    Rarity != Normal
+    SetFontSize 40
+    SetTextColor 0 255 0 255
+    SetBackgroundColor 0 80 0 255
+    MinimapIcon 0 Green Circle
+    PlayEffect Green
+Show
+    Rarity == Normal
+    SetFontSize 35
+    SetTextColor 255 255 255 255
+    SetBackgroundColor 60 60 60 255
+
+#--------------------------------
+# "!=" on a boolean - GREY catch-all
+# Everything else that is NOT corrupted still shows (so nothing disappears).
+#--------------------------------
+Show
+    Corrupted != True
+    SetFontSize 32
+    SetTextColor 200 200 200 255
+    SetBorderColor 80 80 80 255

--- a/src/diagnostics/filterCodeActions.ts
+++ b/src/diagnostics/filterCodeActions.ts
@@ -35,6 +35,14 @@ export class FilterCodeActionProvider implements vscode.CodeActionProvider {
       ) {
         this.handleRuleConflict(diagnostic, actions);
       }
+
+      // Handle direct text replacements (e.g. simplify "!= True" to "False")
+      if (
+        typeof diagnostic.code === "string" &&
+        diagnostic.code.startsWith("replace:")
+      ) {
+        this.handleReplacement(diagnostic, document, actions);
+      }
     });
 
     return actions;
@@ -58,6 +66,28 @@ export class FilterCodeActionProvider implements vscode.CodeActionProvider {
       fix.diagnostics = [diagnostic];
       actions.push(fix);
     });
+  }
+
+  private handleReplacement(
+    diagnostic: vscode.Diagnostic,
+    document: vscode.TextDocument,
+    actions: vscode.CodeAction[]
+  ) {
+    if (typeof diagnostic.code !== "string") {
+      return;
+    }
+
+    const replacement = diagnostic.code.slice("replace:".length);
+    const fix = new vscode.CodeAction(
+      `Change to '${replacement}'`,
+      vscode.CodeActionKind.QuickFix
+    );
+
+    fix.edit = new vscode.WorkspaceEdit();
+    fix.edit.replace(document.uri, diagnostic.range, replacement);
+    fix.diagnostics = [diagnostic];
+    fix.isPreferred = true;
+    actions.push(fix);
   }
 
   private handleRuleConflict(

--- a/src/diagnostics/filterDiagnostics.ts
+++ b/src/diagnostics/filterDiagnostics.ts
@@ -177,9 +177,15 @@ function extractCommandsFromGrammar(): Record<string, CommandDefinition> {
               return /^(?:"[^"]*"(?:\s+"[^"]*")*|\S+)$/;
             }
 
-            // Handle comparison operators
-            if (groupPattern === "==|=") {
-              return /^(?:==|=)$/;
+            // Handle comparison operators (e.g. "==|!=|=|!" or ">=|<=|==|!=|=|!|<|>")
+            const operatorAlternatives = groupPattern.split("|");
+            if (
+              operatorAlternatives.length > 0 &&
+              operatorAlternatives.every((alt) =>
+                /^(==|!=|>=|<=|=|!|<|>)$/.test(alt)
+              )
+            ) {
+              return new RegExp(`^(?:${groupPattern})$`);
             }
 
             // Handle other simple patterns (like numbers, enums)
@@ -274,6 +280,18 @@ function getParamTypeFromScope(scope: string): string {
 
 // Use the extracted commands
 const VALID_COMMANDS = extractCommandsFromGrammar();
+
+// Conditions that take a True/False value. Writing them with a "not equal"
+// operator (e.g. "Corrupted != True") is valid but confusing, so we suggest
+// the simpler inverted form ("Corrupted False").
+const BOOLEAN_CONDITIONS = new Set([
+  "FracturedItem",
+  "Mirrored",
+  "Corrupted",
+  "SynthesisedItem",
+  "AnyEnchantment",
+  "Identified",
+]);
 
 // TODO: detect nested blocks
 // TODO: detect empty blocks
@@ -461,6 +479,45 @@ function validateSoundFile(
   }
 }
 
+/**
+ * Flags the confusing "BooleanCondition != True/False" form and suggests the
+ * simpler inverted value (e.g. "Corrupted != True" -> "Corrupted False").
+ */
+function validateBooleanCondition(
+  command: string,
+  parts: string[],
+  line: vscode.TextLine,
+  problems: vscode.Diagnostic[]
+) {
+  const rest = parts.slice(1);
+  const hasOperator =
+    rest[0] !== undefined && /^(==|!=|>=|<=|=|!|<|>)$/.test(rest[0]);
+  const operator = hasOperator ? rest[0] : undefined;
+  const value = hasOperator ? rest[1] : rest[0];
+
+  const isNotEqual = operator === "!" || operator === "!=";
+  if (!isNotEqual || (value !== "True" && value !== "False")) {
+    return;
+  }
+
+  const inverted = value === "True" ? "False" : "True";
+
+  const commandEnd = line.text.indexOf(command) + command.length;
+  const operatorIndex = line.text.indexOf(operator!, commandEnd);
+  const valueIndex = line.text.indexOf(value, operatorIndex + operator!.length);
+
+  const diagnostic = createDiagnostic(
+    new vscode.Range(
+      line.range.start.translate(0, operatorIndex),
+      line.range.start.translate(0, valueIndex + value.length)
+    ),
+    `"${command} ${operator} ${value}" is confusing. Use "${command} ${inverted}" instead.`,
+    vscode.DiagnosticSeverity.Warning
+  );
+  diagnostic.code = `replace:${inverted}`;
+  problems.push(diagnostic);
+}
+
 export function validateDocument(
   document: vscode.TextDocument,
   gameData: GameDataService
@@ -540,6 +597,11 @@ export function validateDocument(
       continue;
     }
 
+    // Suggest the simpler form for confusing "Corrupted != True" style usage
+    if (BOOLEAN_CONDITIONS.has(command)) {
+      validateBooleanCondition(command, parts, line, problems);
+    }
+
     // Validate parameters based on command definition
     validateCommandParams(command, parts.slice(1), line, problems);
   }
@@ -584,7 +646,7 @@ function validateCommandParams(
         return value.startsWith('"') && value.endsWith('"') ? 1 : -1;
 
       case "operator":
-        return /^[=<>]=?$/.test(value) ? 1 : -1;
+        return /^(==|!=|>=|<=|=|!|<|>)$/.test(value) ? 1 : -1;
 
       case "enum":
         // For enums, prefer exact matches over just valid identifiers
@@ -613,7 +675,7 @@ function validateCommandParams(
     // Penalize if the first parameter is an operator but none was provided
     if (
       paramSet.params[0]?.type === "operator" &&
-      !values[0]?.match(/^[=<>]/)
+      !values[0]?.match(/^[=<>!]/)
     ) {
       matchScore -= 500;
     }
@@ -835,7 +897,7 @@ function validateBaseTypeOrClass(
     value
       .match(/"[^"]*"|[^\s"]+/g)
       ?.map((v) => v.replace(/^"(.*)"$/, "$1")) // Extract quoted strings or single words
-      .filter((v) => !v.match(/^[=<>]=?$/)) || []; // Filter out operators
+      .filter((v) => !v.match(/^(==|!=|>=|<=|=|!|<|>)$/)) || []; // Filter out operators
 
   const isExact = line.text.includes("==");
 

--- a/src/parser/filterRuleEngine.ts
+++ b/src/parser/filterRuleEngine.ts
@@ -101,6 +101,22 @@ function isNotEqualOperator(operator?: string): boolean {
 }
 
 /**
+ * Case-insensitive substring match used for "not equal" BaseType/Class
+ * comparisons, mirroring how the game matches partial names (e.g. "Jade"
+ * excludes "Jade Amulet").
+ */
+function partiallyMatchesAnyValue(
+  itemValue: string | undefined,
+  values: string[]
+): boolean {
+  if (!itemValue) {
+    return false;
+  }
+  const target = itemValue.toLowerCase();
+  return values.some((value) => target.includes(value.toLowerCase()));
+}
+
+/**
  * Resolves the boolean value a True/False condition expects, taking a
  * "not equal" operator (e.g. "Corrupted != True") into account.
  */
@@ -116,16 +132,22 @@ export function wouldRuleMatchItem(
   for (const condition of rule.conditions) {
     switch (condition.type) {
       case "BaseType": {
-        const inList =
-          !!item.baseType && condition.values.includes(item.baseType);
-        if (isNotEqualOperator(condition.operator) ? inList : !inList) {
+        if (isNotEqualOperator(condition.operator)) {
+          // Partial match so e.g. "Jade" excludes "Jade Amulet"
+          if (partiallyMatchesAnyValue(item.baseType, condition.values)) {
+            return false;
+          }
+        } else if (!item.baseType || !condition.values.includes(item.baseType)) {
           return false;
         }
         break;
       }
       case "Class": {
-        const inList = !!item.class && condition.values.includes(item.class);
-        if (isNotEqualOperator(condition.operator) ? inList : !inList) {
+        if (isNotEqualOperator(condition.operator)) {
+          if (partiallyMatchesAnyValue(item.class, condition.values)) {
+            return false;
+          }
+        } else if (!item.class || !condition.values.includes(item.class)) {
           return false;
         }
         break;

--- a/src/parser/filterRuleEngine.ts
+++ b/src/parser/filterRuleEngine.ts
@@ -92,22 +92,44 @@ type NumericProps = Exclude<
   undefined
 >;
 
+/**
+ * Returns true when the operator represents a "not equal" comparison.
+ * PoE2 supports both "!" and "!=" as not-equal operators.
+ */
+function isNotEqualOperator(operator?: string): boolean {
+  return operator === "!" || operator === "!=";
+}
+
+/**
+ * Resolves the boolean value a True/False condition expects, taking a
+ * "not equal" operator (e.g. "Corrupted != True") into account.
+ */
+function expectedBoolean(condition: FilterCondition): boolean {
+  const isTrue = condition.values[0] === "True";
+  return isNotEqualOperator(condition.operator) ? !isTrue : isTrue;
+}
+
 export function wouldRuleMatchItem(
   rule: FilterRule,
   item: FilterItem
 ): boolean {
   for (const condition of rule.conditions) {
     switch (condition.type) {
-      case "BaseType":
-        if (!item.baseType || !condition.values.includes(item.baseType)) {
+      case "BaseType": {
+        const inList =
+          !!item.baseType && condition.values.includes(item.baseType);
+        if (isNotEqualOperator(condition.operator) ? inList : !inList) {
           return false;
         }
         break;
-      case "Class":
-        if (!item.class || !condition.values.includes(item.class)) {
+      }
+      case "Class": {
+        const inList = !!item.class && condition.values.includes(item.class);
+        if (isNotEqualOperator(condition.operator) ? inList : !inList) {
           return false;
         }
         break;
+      }
       case "Sockets":
       case "Quality":
       case "ItemLevel":
@@ -133,38 +155,40 @@ export function wouldRuleMatchItem(
         }
         break;
       }
-      case "Rarity":
-        if (!item.rarity || !condition.values.includes(item.rarity)) {
+      case "Rarity": {
+        const inList = !!item.rarity && condition.values.includes(item.rarity);
+        if (isNotEqualOperator(condition.operator) ? inList : !inList) {
           return false;
         }
         break;
+      }
       case "FracturedItem":
-        if (item.fractured !== (condition.values[0] === "True")) {
+        if (item.fractured !== expectedBoolean(condition)) {
           return false;
         }
         break;
       case "Mirrored":
-        if (item.mirrored !== (condition.values[0] === "True")) {
+        if (item.mirrored !== expectedBoolean(condition)) {
           return false;
         }
         break;
       case "Corrupted":
-        if (item.corrupted !== (condition.values[0] === "True")) {
+        if (item.corrupted !== expectedBoolean(condition)) {
           return false;
         }
         break;
       case "SynthesisedItem":
-        if (item.synthesised !== (condition.values[0] === "True")) {
+        if (item.synthesised !== expectedBoolean(condition)) {
           return false;
         }
         break;
       case "AnyEnchantment":
-        if (item.enchanted !== (condition.values[0] === "True")) {
+        if (item.enchanted !== expectedBoolean(condition)) {
           return false;
         }
         break;
       case "Identified":
-        if (item.identified !== (condition.values[0] === "True")) {
+        if (item.identified !== expectedBoolean(condition)) {
           return false;
         }
         break;
@@ -299,12 +323,18 @@ export function generateItemFromRule(rule: FilterRule): FilterItem {
   for (const condition of rule.conditions) {
     switch (condition.type) {
       case "BaseType":
-        item.baseType = condition.values[0];
-        baseTypes.push(condition.values[0]);
+        // For "not equal" we can't represent the rule with the excluded value,
+        // so we leave baseType unset to avoid a self-contradicting item.
+        if (!isNotEqualOperator(condition.operator)) {
+          item.baseType = condition.values[0];
+          baseTypes.push(condition.values[0]);
+        }
         break;
       case "Class":
-        item.class = condition.values[0];
-        classes.push(condition.values[0]);
+        if (!isNotEqualOperator(condition.operator)) {
+          item.class = condition.values[0];
+          classes.push(condition.values[0]);
+        }
         break;
       case "Sockets":
       case "Quality":
@@ -339,32 +369,44 @@ export function generateItemFromRule(rule: FilterRule): FilterItem {
               item[prop] = value - 1;
               break;
             case "==":
+            case "=":
               item[prop] = value;
+              break;
+            case "!=":
+            case "!":
+              // Any value other than the excluded one satisfies "not equal".
+              item[prop] = value + 1;
               break;
           }
         }
         break;
       }
       case "Rarity":
-        item.rarity = condition.values[0];
+        if (isNotEqualOperator(condition.operator)) {
+          item.rarity = ["Normal", "Magic", "Rare", "Unique"].find(
+            (rarity) => !condition.values.includes(rarity)
+          );
+        } else {
+          item.rarity = condition.values[0];
+        }
         break;
       case "FracturedItem":
-        item.fractured = condition.values[0] === "True";
+        item.fractured = expectedBoolean(condition);
         break;
       case "Mirrored":
-        item.mirrored = condition.values[0] === "True";
+        item.mirrored = expectedBoolean(condition);
         break;
       case "Corrupted":
-        item.corrupted = condition.values[0] === "True";
+        item.corrupted = expectedBoolean(condition);
         break;
       case "SynthesisedItem":
-        item.synthesised = condition.values[0] === "True";
+        item.synthesised = expectedBoolean(condition);
         break;
       case "AnyEnchantment":
-        item.enchanted = condition.values[0] === "True";
+        item.enchanted = expectedBoolean(condition);
         break;
       case "Identified":
-        item.identified = condition.values[0] === "True";
+        item.identified = expectedBoolean(condition);
         break;
       default: {
         const _exhaustiveCheck: never = condition.type;
@@ -409,7 +451,11 @@ export function compareNumeric(
     case "<":
       return value < conditionValue;
     case "==":
+    case "=":
       return value === conditionValue;
+    case "!=":
+    case "!":
+      return value !== conditionValue;
     default:
       return false;
   }
@@ -484,8 +530,8 @@ export function parseCondition(
   switch (type) {
     case "Class":
     case "BaseType": {
-      // Check for operator before the first quote
-      const operatorMatch = text.match(/\s+([=]{1,2})\s+/);
+      // Check for operator before the first quote (=, ==, !, !=)
+      const operatorMatch = text.match(/\s+(==|!=|=|!)\s+/);
       // Match all quoted strings, preserving spaces within quotes
       const matches = text.match(/"([^"]+)"/g) || [];
       return {
@@ -511,7 +557,7 @@ export function parseCondition(
     case "BaseEvasion":
       return {
         type,
-        operator: parts[1]?.match(/[<>=]+/)?.[0],
+        operator: parts[1]?.match(/[<>=!]+/)?.[0],
         values: [parts[parts.length - 1]],
         lineNumber,
       };
@@ -531,7 +577,8 @@ export function parseCondition(
     case "Identified":
       return {
         type,
-        values: [parts[1]], // True/False
+        operator: parts[1]?.match(/^(==|!=|=|!)$/)?.[0],
+        values: [parts[parts.length - 1]], // True/False
         lineNumber,
       };
     default:

--- a/src/preview/FilterPreviewEditor.ts
+++ b/src/preview/FilterPreviewEditor.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import {
   FilterItem,
   FilterRule,
+  FilterCondition,
   wouldRuleMatchItem,
   generateItemFromRule,
   parseRules,
@@ -16,6 +17,9 @@ import {
 
 type ExtendedFilterItem = FilterItem & {
   ruleLineNumber?: number;
+  // Marks an item generated to illustrate a not-equal rule's exception
+  // (i.e. a base the rule deliberately lets through).
+  isException?: boolean;
 };
 
 export class FilterPreviewEditor
@@ -279,7 +283,7 @@ export class FilterPreviewEditor
                 ctx.fillStyle = 'rgba(255, 0, 0, 0.8)';
                 ctx.fillText('HIDDEN', x, y + textHeight/2 + padding + hiddenFontSize/2);
               }
-                                                      
+
               ctx.restore();
             }
             
@@ -491,10 +495,10 @@ export class FilterPreviewEditor
               const hoveredItem = items.find(item => isMouseOverItem(mouseX, mouseY, item));
               
               if (hoveredItem) {
-                const skipProps = ['x', 'y', 'matched', 'hidden', 'textColor', 'fontSize', 'borderColor', 'backgroundColor', 'beam'];
+                const skipProps = ['x', 'y', 'matched', 'hidden', 'textColor', 'fontSize', 'borderColor', 'backgroundColor', 'beam', 'isException'];
                 const formatKey = (key) => key.replace(/([A-Z])/g, ' $1').replace(/^./, str => str.toUpperCase());
                 
-                const details = Object.entries(hoveredItem)
+                let details = Object.entries(hoveredItem)
                   .sort(([keyA], [keyB]) => {
                     if (keyA === 'name') return -1;
                     if (keyB === 'name') return 1;
@@ -507,7 +511,15 @@ export class FilterPreviewEditor
                     return acc;
                   }, [])
                   .join('\\n');
-                
+
+                // Explain preview-only "exception" items (a base type the rule's
+                // not-equal BaseType condition deliberately lets through).
+                if (hoveredItem.isException) {
+                  details =
+                    'Preview example: this base type is excluded by this rule (BaseType ! / !=), so the rule does not match it here — other rules decide how it looks.\\n\\n' +
+                    details;
+                }
+
                 tooltip.textContent = details;
                 tooltip.style.display = 'block';
                 
@@ -763,6 +775,82 @@ export class FilterPreviewEditor
     });
   }
 
+  private _pickRandom<T>(items: T[]): T | undefined {
+    if (items.length === 0) {
+      return undefined;
+    }
+    return items[Math.floor(Math.random() * items.length)];
+  }
+
+  /**
+   * Returns the base items belonging to the class(es) referenced by a Class
+   * condition, falling back to all base items when there is no usable match.
+   */
+  private _getClassBaseItems(
+    classCondition: FilterCondition | undefined
+  ): BaseItemType[] {
+    if (!classCondition) {
+      return this.gameData.baseItemTypes;
+    }
+    const classMatches = this.gameData.findMatchingClasses(
+      classCondition.values
+    );
+    if (classMatches.length === 0) {
+      return this.gameData.baseItemTypes;
+    }
+    const classIndexes = new Set(classMatches.map((m) => m.item._index));
+    const filtered = this.gameData.baseItemTypes.filter((b) =>
+      classIndexes.has(b.ItemClass)
+    );
+    return filtered.length > 0 ? filtered : this.gameData.baseItemTypes;
+  }
+
+  /**
+   * For a rule using a not-equal BaseType (e.g. `BaseType ! "Jade" "Lapis"`),
+   * generates two representative items:
+   *  - the item the rule actually catches (a base NOT in the excluded list)
+   *  - the exception the rule lets through (one of the excluded bases), flagged
+   *    so the preview can show how it renders when this rule does not apply.
+   */
+  private _generateNotEqualBaseTypeItems(
+    rule: FilterRule,
+    baseTypeCondition: FilterCondition,
+    classCondition: FilterCondition | undefined
+  ): ExtendedFilterItem[] {
+    const result: ExtendedFilterItem[] = [];
+    const excluded = baseTypeCondition.values.map((v) => v.toLowerCase());
+    const classItems = this._getClassBaseItems(classCondition);
+
+    const matchesExcluded = (b: BaseItemType) =>
+      excluded.some((e) => b.Name.toLowerCase().includes(e));
+
+    const caughtBase = this._pickRandom(
+      classItems.filter((b) => !matchesExcluded(b))
+    );
+    const caughtItem = generateItemFromRule(rule);
+    if (caughtBase) {
+      caughtItem.baseType = caughtBase.Name;
+      caughtItem.name = caughtBase.Name;
+      caughtItem.dropLevel = caughtBase.DropLevel;
+    }
+    result.push({ ...caughtItem, ruleLineNumber: rule.lineNumber });
+
+    const exceptionBase = this._pickRandom(classItems.filter(matchesExcluded));
+    if (exceptionBase) {
+      const exceptionItem = generateItemFromRule(rule);
+      exceptionItem.baseType = exceptionBase.Name;
+      exceptionItem.name = exceptionBase.Name;
+      exceptionItem.dropLevel = exceptionBase.DropLevel;
+      result.push({
+        ...exceptionItem,
+        ruleLineNumber: rule.lineNumber,
+        isException: true,
+      });
+    }
+
+    return result;
+  }
+
   private _generateItemsFromRules(rules: FilterRule[]): ExtendedFilterItem[] {
     const items: ExtendedFilterItem[] = [];
 
@@ -772,6 +860,23 @@ export class FilterPreviewEditor
         (c) => c.type === "BaseType"
       );
       const classCondition = rule.conditions.find((c) => c.type === "Class");
+
+      // not-equal BaseType: render a caught item plus the exception it lets through
+      if (
+        baseTypeCondition &&
+        (baseTypeCondition.operator === "!" ||
+          baseTypeCondition.operator === "!=")
+      ) {
+        items.push(
+          ...this._generateNotEqualBaseTypeItems(
+            rule,
+            baseTypeCondition,
+            classCondition
+          )
+        );
+        continue;
+      }
+
       const areaLevelCondition = rule.conditions.find(
         (c) => c.type === "AreaLevel"
       );

--- a/syntaxes/poe2filter.tmLanguage.json
+++ b/syntaxes/poe2filter.tmLanguage.json
@@ -57,7 +57,7 @@
           "end": "(?=$|#)",
           "patterns": [
             {
-              "match": "(>=|<=|==|=|<|>)\\s+(Normal|Magic|Rare|Unique)\\b",
+              "match": "(>=|<=|==|!=|=|!|<|>)\\s+(Normal|Magic|Rare|Unique)\\b",
               "captures": {
                 "1": { "name": "keyword.operator.comparison.poe2filter" },
                 "2": { "name": "variable.parameter.rarity.poe2filter" }
@@ -79,7 +79,7 @@
           "end": "(?=$|#)",
           "patterns": [
             {
-              "match": "(==|=)\\s+(\"[^\"]+\")",
+              "match": "(==|!=|=|!)\\s+(\"[^\"]+\")",
               "captures": {
                 "1": { "name": "keyword.operator.comparison.poe2filter" },
                 "2": { "name": "string.quoted.double.basetype.poe2filter" }
@@ -101,7 +101,7 @@
           "end": "(?=$|#)",
           "patterns": [
             {
-              "match": "(>=|<=|==|=|<|>)\\s+(\\d+)\\b",
+              "match": "(>=|<=|==|!=|=|!|<|>)\\s+(\\d+)\\b",
               "captures": {
                 "1": { "name": "keyword.operator.comparison.poe2filter" },
                 "2": { "name": "constant.numeric.level.poe2filter" }
@@ -122,6 +122,13 @@
           },
           "end": "(?=$|#)",
           "patterns": [
+            {
+              "match": "(==|!=|=|!)\\s+(True|False)\\b",
+              "captures": {
+                "1": { "name": "keyword.operator.comparison.poe2filter" },
+                "2": { "name": "constant.language.boolean.poe2filter" }
+              }
+            },
             {
               "match": "\\b(True|False)\\b",
               "captures": {


### PR DESCRIPTION
## Summary

Adds support for the `!` and `!=` (not equal) operators, which are valid in PoE2 item filters but were previously unhandled — they broke syntax highlighting, were flagged as errors, and weren't evaluated by the preview/conflict logic.

Closes #125

### Operator support (`feat`)
- **Grammar**: highlight/validate `!` and `!=` across `Rarity`, numeric conditions, and `BaseType`/`Class`, and allow operators on boolean conditions (`Corrupted`, `Mirrored`, etc.) so `Corrupted != True` no longer errors.
- **Diagnostics**: recognise `!`/`!=` as operators everywhere (regex extraction, scoring, `BaseType`/`Class` operator filtering).
- **Rule engine**: parse the operators and evaluate not-equal correctly in `compareNumeric`, `generateItemFromRule`, and `wouldRuleMatchItem` (numeric, `BaseType`/`Class`, `Rarity`, and booleans).
- **UX**: warn (with a quick-fix) on the confusing `Corrupted != True` form, suggesting the clearer `Corrupted False`.

### Preview fix (`fix`)
- The preview used to pick the very base types a not-equal rule **excludes** (and ignored the `Class` filter), rendering e.g. `Jade Tiara` as HIDDEN for `BaseType ! "Jade"`. It now:
  - uses partial matching for not-equal `BaseType`/`Class` (equality matching unchanged),
  - generates a class-correct **caught** item the rule actually matches,
  - generates an **exception** item (an excluded base) that falls through to other rules, explained via the hover tooltip.

### Examples
- `examples/not-equal-operators.filter` — focused, low-level-friendly test of `!`/`!=` across condition types.
- `examples/issue-125-op-filter.filter` — the reporter's real-world filter.

## Test plan
- [x] `tsc`, `eslint`, and esbuild build pass
- [x] Manual: filters load in-game without syntax errors; `!`/`!=` highlight correctly
- [x] Manual: no false "operator invalid" / "BaseType not found" diagnostics on `BaseType ! "..."`
- [x] Manual: `Corrupted != True` shows the simplify warning + quick-fix
- [x] Manual: preview shows a hidden caught base + a visible exception base (tooltip explains it)

Made with [Cursor](https://cursor.com)