### PR TITLE
✨ Add PoE2 filter conditions (incl. HasExplicitMod)

### DIFF
--- a/examples/new-conditions.filter
+++ b/examples/new-conditions.filter
@@ -1,0 +1,80 @@
+# PoE2 Conditions Coverage Test Filter
+# Conditions added to the extension's grammar + preview, each present in
+# real PoE2 filters and/or listed in the PoE2 "Last of the Druids" item
+# filter post.
+#
+# What to check:
+#   - No line below is flagged as "Unknown command".
+#   - Numeric conditions accept an operator + number; booleans accept
+#     True/False (and the simpler-form suggestion fires on "!= True").
+#   - In game: load this filter and confirm each rule actually affects the
+#     matching drop. PoE2 is Early Access and may silently ignore some.
+
+#--------------------------------
+# Numeric (UnidentifiedItemTier: 108x in real PoE2 filters)
+#--------------------------------
+Show
+    UnidentifiedItemTier >= 4
+    SetTextColor 255 0 0 255
+
+#--------------------------------
+# HasExplicitMod (20x in real PoE2 filters). Syntax confirmed in-game (issue #11):
+#   HasExplicitMod [<op><count> | True] mod [mod ...]
+# - operator/count is optional; when present it must be GLUED (">=6", not ">= 6")
+# - at least one mod required (quotes optional; matched partially)
+# - valid operators: == > < >= <= and True  (NOT != or False)
+#--------------------------------
+Show
+    HasExplicitMod >=1 "King's" "Empowering"
+    SetBorderColor 255 255 255 255
+
+Show
+    HasExplicitMod "Populated"          # mods only, no operator
+    SetBorderColor 0 200 200 255
+
+Show
+    HasExplicitMod True "Populated" "Teeming"
+    SetBorderColor 0 200 200 255
+
+# Invalid in-game: a space between the operator and number (flagged as error)
+# Show
+#     HasExplicitMod >= 6 "Populated"
+
+#--------------------------------
+# Booleans confirmed in the PoE2 "Last of the Druids" filter post
+#--------------------------------
+Show
+    AlwaysShow True
+    SetTextColor 255 255 255 255
+
+Show
+    HasVaalUniqueMod True
+    SetBorderColor 200 0 200 255
+
+Show
+    IsVaalUnique True
+    SetBorderColor 200 0 200 255
+
+Show
+    TwiceCorrupted True
+    SetBorderColor 120 0 0 255
+
+#================================================================
+# REMOVED as PoE1-only after research (do NOT re-add without in-game proof):
+#   MemoryStrands  - Secrets of the Atlas, Memory-Influenced T16/T17 maps
+#   MirageMap      - "Path of Exile: Mirage" league
+#   AlternateQuality - PoE1 alternate-quality gems (Anomalous/Divergent/...)
+#   TransfiguredGem - PoE1 (Affliction); no transfig mechanic in PoE2 game data
+#   Imbued         - only an item mod-affix name in PoE2 data, not a filter state
+#
+# NOT ADDED - 0 usage in real PoE2 filters checked, so unverified:
+#   HasInfluence (Shaper/Elder/... - PoE1), HasImplicitMod, HasEnchantment,
+#   LinkedSockets, SocketGroup, CorruptedMods, BaseWard,
+#   BaseDefencePercentile, Replica, Scourged, GemQualityType,
+#   EnchantmentPassiveNode, EnchantmentPassiveNum
+#
+# Probably PoE1-only:
+#   ArchnemesisMod, BlightedMap, UberBlightedMap, ElderItem, ElderMap,
+#   ShaperItem, ShapedMap, HasCruciblePassiveTree,
+#   HasEaterOfWorldsImplicit, HasSearingExarchImplicit, ZanaMemory, Foulborn
+#================================================================

--- a/src/diagnostics/filterDiagnostics.ts
+++ b/src/diagnostics/filterDiagnostics.ts
@@ -291,6 +291,10 @@ const BOOLEAN_CONDITIONS = new Set([
   "SynthesisedItem",
   "AnyEnchantment",
   "Identified",
+  "HasVaalUniqueMod",
+  "IsVaalUnique",
+  "TwiceCorrupted",
+  "AlwaysShow",
 ]);
 
 // TODO: detect nested blocks
@@ -518,6 +522,44 @@ function validateBooleanCondition(
   problems.push(diagnostic);
 }
 
+/**
+ * HasExplicitMod has a bespoke syntax (confirmed in-game, issue #11):
+ *   HasExplicitMod [<op><count> | True] <mod> [<mod> ...]
+ * The operator/count is optional but, when present, must be glued to the
+ * number ("HasExplicitMod >=6 ..."); the game rejects a space
+ * ("HasExplicitMod >= 6 ..."). Mod names are matched partially and may be
+ * unquoted, so the list itself isn't validated - we only flag the spacing.
+ */
+function validateHasExplicitMod(
+  parts: string[],
+  line: vscode.TextLine,
+  problems: vscode.Diagnostic[]
+) {
+  const operator = parts[1];
+  const number = parts[2];
+  const isSpacedOperator =
+    /^(==|>=|<=|<|>)$/.test(operator ?? "") && /^\d+$/.test(number ?? "");
+  if (!isSpacedOperator) {
+    return;
+  }
+
+  const commandEnd =
+    line.text.indexOf("HasExplicitMod") + "HasExplicitMod".length;
+  const operatorIndex = line.text.indexOf(operator, commandEnd);
+  const numberIndex = line.text.indexOf(number, operatorIndex + operator.length);
+
+  problems.push(
+    createDiagnostic(
+      new vscode.Range(
+        line.range.start.translate(0, operatorIndex),
+        line.range.start.translate(0, numberIndex + number.length)
+      ),
+      `HasExplicitMod requires no space between the operator and number. Use "${operator}${number}".`,
+      vscode.DiagnosticSeverity.Error
+    )
+  );
+}
+
 export function validateDocument(
   document: vscode.TextDocument,
   gameData: GameDataService
@@ -594,6 +636,14 @@ export function validateDocument(
           command === "CustomAlertSoundOptional"
         );
       }
+      continue;
+    }
+
+    // HasExplicitMod uses a bespoke "count + mod-name list" form that does not
+    // fit the generic parameter validator. We only flag the one guaranteed
+    // client error (a space between the operator and number).
+    if (command === "HasExplicitMod") {
+      validateHasExplicitMod(parts, line, problems);
       continue;
     }
 

--- a/src/parser/filterRuleEngine.ts
+++ b/src/parser/filterRuleEngine.ts
@@ -17,13 +17,19 @@ type ConditionType =
   | "BaseArmour"
   | "BaseEnergyShield"
   | "BaseEvasion"
+  | "UnidentifiedItemTier"
   | "Rarity"
   | "FracturedItem"
   | "Mirrored"
   | "Corrupted"
   | "SynthesisedItem"
   | "AnyEnchantment"
-  | "Identified";
+  | "Identified"
+  | "HasVaalUniqueMod"
+  | "IsVaalUnique"
+  | "TwiceCorrupted"
+  | "AlwaysShow"
+  | "HasExplicitMod";
 
 type ActionType =
   | "SetFontSize"
@@ -70,6 +76,7 @@ export interface FilterItem {
   baseArmour?: number;
   baseEnergyShield?: number;
   baseEvasion?: number;
+  unidentifiedItemTier?: number;
   // String properties
   baseType?: string;
   class?: string;
@@ -82,6 +89,13 @@ export interface FilterItem {
   synthesised?: boolean;
   enchanted?: boolean;
   identified?: boolean;
+  hasVaalUniqueMod?: boolean;
+  isVaalUnique?: boolean;
+  twiceCorrupted?: boolean;
+  alwaysShow?: boolean;
+  // Explicit mod names a HasExplicitMod rule requires (string list, so it is
+  // not part of NumericProps/boolean handling).
+  explicitMods?: string[];
 }
 type NumericProps = Exclude<
   {
@@ -165,7 +179,8 @@ export function wouldRuleMatchItem(
       case "Width":
       case "BaseArmour":
       case "BaseEnergyShield":
-      case "BaseEvasion": {
+      case "BaseEvasion":
+      case "UnidentifiedItemTier": {
         const prop = (condition.type.charAt(0).toLowerCase() +
           condition.type.slice(1)) as NumericProps;
         if (
@@ -214,6 +229,39 @@ export function wouldRuleMatchItem(
           return false;
         }
         break;
+      case "HasVaalUniqueMod":
+        if (item.hasVaalUniqueMod !== expectedBoolean(condition)) {
+          return false;
+        }
+        break;
+      case "IsVaalUnique":
+        if (item.isVaalUnique !== expectedBoolean(condition)) {
+          return false;
+        }
+        break;
+      case "TwiceCorrupted":
+        if (item.twiceCorrupted !== expectedBoolean(condition)) {
+          return false;
+        }
+        break;
+      case "AlwaysShow":
+        if (item.alwaysShow !== expectedBoolean(condition)) {
+          return false;
+        }
+        break;
+      case "HasExplicitMod": {
+        // The preview cannot simulate item mod rolls, so only an item that
+        // explicitly carries the required mods matches (the rule's own
+        // representative item does; sample items do not).
+        const required = condition.values;
+        const matches =
+          !!item.explicitMods &&
+          required.every((mod) => item.explicitMods!.includes(mod));
+        if (isNotEqualOperator(condition.operator) ? matches : !matches) {
+          return false;
+        }
+        break;
+      }
       default: {
         const _exhaustiveCheck: never = condition.type;
         return false;
@@ -331,6 +379,7 @@ export function generateItemFromRule(rule: FilterRule): FilterItem {
     baseArmour: 0,
     baseEnergyShield: 0,
     baseEvasion: 0,
+    unidentifiedItemTier: 0,
     // Boolean defaults
     fractured: false,
     mirrored: false,
@@ -338,6 +387,13 @@ export function generateItemFromRule(rule: FilterRule): FilterItem {
     synthesised: false,
     enchanted: false,
     identified: false,
+    hasVaalUniqueMod: false,
+    isVaalUnique: false,
+    twiceCorrupted: false,
+    alwaysShow: false,
+    // Fallback so a rule whose conditions don't determine a base item (e.g.
+    // boolean-only rules) still renders with a label instead of "undefined".
+    name: "Item",
   };
 
   let baseTypes: string[] = [];
@@ -371,7 +427,8 @@ export function generateItemFromRule(rule: FilterRule): FilterItem {
       case "Width":
       case "BaseArmour":
       case "BaseEnergyShield":
-      case "BaseEvasion": {
+      case "BaseEvasion":
+      case "UnidentifiedItemTier": {
         const prop = (condition.type.charAt(0).toLowerCase() +
           condition.type.slice(1)) as NumericProps;
 
@@ -429,6 +486,22 @@ export function generateItemFromRule(rule: FilterRule): FilterItem {
         break;
       case "Identified":
         item.identified = expectedBoolean(condition);
+        break;
+      case "HasVaalUniqueMod":
+        item.hasVaalUniqueMod = expectedBoolean(condition);
+        break;
+      case "IsVaalUnique":
+        item.isVaalUnique = expectedBoolean(condition);
+        break;
+      case "TwiceCorrupted":
+        item.twiceCorrupted = expectedBoolean(condition);
+        break;
+      case "AlwaysShow":
+        item.alwaysShow = expectedBoolean(condition);
+        break;
+      case "HasExplicitMod":
+        // Give the representative item the required mods so it matches itself.
+        item.explicitMods = condition.values;
         break;
       default: {
         const _exhaustiveCheck: never = condition.type;
@@ -577,6 +650,7 @@ export function parseCondition(
     case "BaseArmour":
     case "BaseEnergyShield":
     case "BaseEvasion":
+    case "UnidentifiedItemTier":
       return {
         type,
         operator: parts[1]?.match(/[<>=!]+/)?.[0],
@@ -597,12 +671,36 @@ export function parseCondition(
     case "SynthesisedItem":
     case "AnyEnchantment":
     case "Identified":
+    case "HasVaalUniqueMod":
+    case "IsVaalUnique":
+    case "TwiceCorrupted":
+    case "AlwaysShow":
       return {
         type,
         operator: parts[1]?.match(/^(==|!=|=|!)$/)?.[0],
         values: [parts[parts.length - 1]], // True/False
         lineNumber,
       };
+    case "HasExplicitMod": {
+      // Form: HasExplicitMod [<op><count> | True] mod [mod ...]
+      // The operator/count is optional and glued to the number (">=6"); mod
+      // names may be quoted or unquoted and are matched partially in-game.
+      const operator = parts[1]?.match(/^(==|>=|<=|<|>)/)?.[0];
+      const quoted = text.match(/"([^"]+)"/g);
+      const modNames = quoted
+        ? quoted.map((m) => m.replace(/"/g, ""))
+        : parts
+            .slice(1)
+            .filter(
+              (p) => p !== "True" && !/^(==|>=|<=|<|>)?\d+$/.test(p)
+            );
+      return {
+        type,
+        operator,
+        values: modNames,
+        lineNumber,
+      };
+    }
     default:
       const _exhaustiveCheck: never = type;
       return null;

--- a/syntaxes/poe2filter.tmLanguage.json
+++ b/syntaxes/poe2filter.tmLanguage.json
@@ -94,7 +94,7 @@
           ]
         },
         {
-          "begin": "\\b(ItemLevel|DropLevel|Quality|AreaLevel|GemLevel|Sockets|MapTier|WaystoneTier|StackSize|Height|Width|BaseArmour|BaseEnergyShield|BaseEvasion)\\b",
+          "begin": "\\b(ItemLevel|DropLevel|Quality|AreaLevel|GemLevel|Sockets|MapTier|WaystoneTier|StackSize|Height|Width|BaseArmour|BaseEnergyShield|BaseEvasion|UnidentifiedItemTier)\\b",
           "beginCaptures": {
             "1": { "name": "support.function.poe2filter" }
           },
@@ -116,7 +116,7 @@
           ]
         },
         {
-          "begin": "\\b(FracturedItem|Mirrored|Corrupted|SynthesisedItem|AnyEnchantment|Identified)\\b",
+          "begin": "\\b(FracturedItem|Mirrored|Corrupted|SynthesisedItem|AnyEnchantment|Identified|HasVaalUniqueMod|IsVaalUnique|TwiceCorrupted|AlwaysShow)\\b",
           "beginCaptures": {
             "1": { "name": "support.function.poe2filter" }
           },
@@ -133,6 +133,34 @@
               "match": "\\b(True|False)\\b",
               "captures": {
                 "1": { "name": "constant.language.boolean.poe2filter" }
+              }
+            }
+          ]
+        },
+        {
+          "begin": "\\b(HasExplicitMod)\\b",
+          "beginCaptures": {
+            "1": { "name": "support.function.poe2filter" }
+          },
+          "end": "(?=$|#)",
+          "patterns": [
+            {
+              "match": "(==|>=|<=|<|>)(\\d+)\\b",
+              "captures": {
+                "1": { "name": "keyword.operator.comparison.poe2filter" },
+                "2": { "name": "constant.numeric.level.poe2filter" }
+              }
+            },
+            {
+              "match": "\\b(True)\\b",
+              "captures": {
+                "1": { "name": "constant.language.boolean.poe2filter" }
+              }
+            },
+            {
+              "match": "(\"[^\"]+\")",
+              "captures": {
+                "1": { "name": "string.quoted.double.basetype.poe2filter" }
               }
             }
           ]


### PR DESCRIPTION
## Summary
- Adds PoE2 filter conditions: `UnidentifiedItemTier` (numeric); `HasVaalUniqueMod`, `IsVaalUnique`, `TwiceCorrupted`, `AlwaysShow` (boolean); and `HasExplicitMod`.
- Fixes the `HasExplicitMod` error reported in #11 by supporting its bespoke syntax.
- Wires each condition through the grammar, diagnostics (auto-derived command list + `BOOLEAN_CONDITIONS`), and the rule engine (`ConditionType`/`FilterItem`/`parseCondition`/`wouldRuleMatchItem`/`generateItemFromRule`). Boolean-only rules now render a default preview label instead of "undefined".
- Deliberately **excludes** PoE1-only conditions (`MemoryStrands`, `MirageMap`, `AlternateQuality`, `TransfiguredGem`, `Imbued`) — verified absent from PoE2 game data (patch 4.5.4.1.2).

## HasExplicitMod (#11)
Syntax confirmed in-game in the issue:
`HasExplicitMod [<op><count> | True] mod [mod ...]`
- operator/count is optional and must be **glued** to the number (`>=6`, not `>= 6`)
- valid operators: `==` `>` `<` `>=` `<=` and `True` (not `!=`/`False`)
- at least one mod is required; mods may be quoted or unquoted and match partially
- a diagnostic flags the one guaranteed client error: a space between operator and number

## Verification
- `HasExplicitMod` is verified by direct in-game testing (#11).
- The other conditions appear in real PoE2 filters and the "Last of the Druids" filter post. PoE2 is Early Access, so `examples/new-conditions.filter` includes an in-game checklist.

## Closes
Closes #11

Made with [Cursor](https://cursor.com)