### PR TITLE
✨ Add Import keyword, disabled-value actions, and path tooling

### DIFF
--- a/examples/actions-and-keywords.filter
+++ b/examples/actions-and-keywords.filter
@@ -1,0 +1,47 @@
+# PoE2 Actions & Keywords Coverage Test Filter
+# Demonstrates the actions/keywords added to the extension, taken from the
+# official filter docs (https://www.pathofexile.com/item-filter/about).
+#
+# What to check:
+#   - No line below is flagged as "Unknown command" or an invalid value.
+#   - Import / Optional, None, -1 and the IfAlertSound variants highlight.
+#   - In game: confirm disabled values actually disable (no icon/beam/sound)
+#     and that Import pulls in the referenced file.
+
+#--------------------------------
+# Import another filter (top-level, before any block).
+# "Optional" skips the file if it does not exist.
+#--------------------------------
+Import "MyCustomRules.filter"
+Import "MyOptionalRules.filter" Optional
+
+#--------------------------------
+# Multiple custom sounds (semicolon-separated -> a random one plays),
+# with an optional volume after the last file.
+#--------------------------------
+Show
+    BaseType "Mirror of Kalandra"
+    CustomAlertSound "a.mp3";"b.mp3" 300
+    SetTextColor 255 0 0 255
+
+#--------------------------------
+# Disabled / "None" values.
+#--------------------------------
+Show
+    Class "Currency"
+    PlayAlertSound None
+    CustomAlertSound None
+    MinimapIcon -1
+    PlayEffect None
+    SetTextColor 200 200 200 255
+
+#--------------------------------
+# Drop-sound flags, including the IfAlertSound variants.
+#--------------------------------
+Show
+    Class "Waystones"
+    DisableDropSoundIfAlertSound
+    CustomAlertSound "map.mp3"
+Show
+    BaseType "Gold"
+    EnableDropSoundIfAlertSound

--- a/examples/actions-and-keywords.filter
+++ b/examples/actions-and-keywords.filter
@@ -5,6 +5,7 @@
 # What to check:
 #   - No line below is flagged as "Unknown command" or an invalid value.
 #   - Import / Optional, None, -1 and the IfAlertSound variants highlight.
+#   - The Import path is a clickable link (Ctrl/Cmd+Click opens the file).
 #   - In game: confirm disabled values actually disable (no icon/beam/sound)
 #     and that Import pulls in the referenced file.
 
@@ -12,7 +13,7 @@
 # Import another filter (top-level, before any block).
 # "Optional" skips the file if it does not exist.
 #--------------------------------
-Import "MyCustomRules.filter"
+Import "sound-effects.filter"
 Import "MyOptionalRules.filter" Optional
 
 #--------------------------------

--- a/src/diagnostics/filterDiagnostics.ts
+++ b/src/diagnostics/filterDiagnostics.ts
@@ -212,7 +212,7 @@ function extractCommandsFromGrammar(): Record<string, CommandDefinition> {
     }
 
     // Process each section
-    ["blocks", "controlFlow", "conditions", "actions"].forEach((section) => {
+    ["blocks", "controlFlow", "imports", "conditions", "actions"].forEach((section) => {
       (grammar.repository[section].patterns as CommandPattern[]).forEach(
         (pattern) => {
           const { commands: commandNames, paramSets } =
@@ -585,14 +585,19 @@ export function validateDocument(
       command === "CustomAlertSound" ||
       command === "CustomAlertSoundOptional"
     ) {
-      if (parts[1]) {
-        validateSoundFile(
-          parts[1],
-          line,
-          document,
-          problems,
-          command === "CustomAlertSoundOptional"
-        );
+      // "None" disables the sound. Multiple files may be given as
+      // semicolon-separated quoted paths, in which case a random one plays.
+      if (parts[1] && parts[1] !== "None") {
+        const soundFiles = parts[1].split(";").filter((f) => f.length > 0);
+        for (const soundFile of soundFiles) {
+          validateSoundFile(
+            soundFile,
+            line,
+            document,
+            problems,
+            command === "CustomAlertSoundOptional"
+          );
+        }
       }
       continue;
     }

--- a/src/diagnostics/filterDiagnostics.ts
+++ b/src/diagnostics/filterDiagnostics.ts
@@ -480,6 +480,49 @@ function validateSoundFile(
 }
 
 /**
+ * Warns when a non-Optional `Import "file"` references a file that does not
+ * exist (resolved relative to the current document, as the game does). Optional
+ * imports are skipped because they are allowed to be absent. Severity is a
+ * warning rather than an error since in-game imports may resolve from the
+ * game's filter folder, which can differ from the edited file's location.
+ */
+function validateImport(
+  line: vscode.TextLine,
+  document: vscode.TextDocument,
+  problems: vscode.Diagnostic[]
+) {
+  const match = line.text.match(/^\s*Import\s+"([^"]+)"(\s+Optional\b)?/i);
+  if (!match) {
+    return;
+  }
+
+  const filePath = match[1];
+  const isOptional = Boolean(match[2]);
+  if (isOptional) {
+    return;
+  }
+
+  const resolved = path.isAbsolute(filePath)
+    ? filePath
+    : path.join(path.dirname(document.uri.fsPath), filePath);
+  if (fs.existsSync(resolved)) {
+    return;
+  }
+
+  const startCol = line.text.indexOf(`"${filePath}"`) + 1;
+  problems.push(
+    createDiagnostic(
+      new vscode.Range(
+        line.range.start.translate(0, startCol),
+        line.range.start.translate(0, startCol + filePath.length)
+      ),
+      `Imported filter not found: ${filePath}. Add "Optional" if the file may be absent.`,
+      vscode.DiagnosticSeverity.Warning
+    )
+  );
+}
+
+/**
  * Flags the confusing "BooleanCondition != True/False" form and suggests the
  * simpler inverted value (e.g. "Corrupted != True" -> "Corrupted False").
  */
@@ -599,6 +642,12 @@ export function validateDocument(
           );
         }
       }
+      continue;
+    }
+
+    // Warn when a non-Optional Import points at a missing file
+    if (command === "Import") {
+      validateImport(line, document, problems);
       continue;
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -18,6 +18,7 @@ import { GameDataService } from "./services/gameDataService";
 import { FilterHoverProvider } from "./providers/filterHoverProvider";
 import { FilterDecorationProvider } from "./providers/filterDecorationProvider";
 import { FilterDocumentLinkProvider } from "./providers/filterDocumentLinkProvider";
+import { FilterCompletionProvider } from "./providers/filterCompletionProvider";
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
@@ -85,6 +86,16 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.languages.registerDocumentLinkProvider(
       "poe2-filter",
       new FilterDocumentLinkProvider()
+    )
+  );
+
+  // Register completion of file names inside Import / CustomAlertSound paths
+  context.subscriptions.push(
+    vscode.languages.registerCompletionItemProvider(
+      "poe2-filter",
+      new FilterCompletionProvider(),
+      '"',
+      "/"
     )
   );
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -17,6 +17,7 @@ import path from "path";
 import { GameDataService } from "./services/gameDataService";
 import { FilterHoverProvider } from "./providers/filterHoverProvider";
 import { FilterDecorationProvider } from "./providers/filterDecorationProvider";
+import { FilterDocumentLinkProvider } from "./providers/filterDocumentLinkProvider";
 
 // This method is called when your extension is activated
 // Your extension is activated the very first time the command is executed
@@ -76,6 +77,14 @@ export async function activate(context: vscode.ExtensionContext) {
     vscode.languages.registerDocumentSymbolProvider(
       "poe2-filter",
       new FilterSymbolProvider()
+    )
+  );
+
+  // Register document link provider so Import "file" paths are clickable
+  context.subscriptions.push(
+    vscode.languages.registerDocumentLinkProvider(
+      "poe2-filter",
+      new FilterDocumentLinkProvider()
     )
   );
 

--- a/src/preview/FilterPreviewEditor.ts
+++ b/src/preview/FilterPreviewEditor.ts
@@ -735,10 +735,16 @@ export class FilterPreviewEditor
                 .map((v) => parseInt(v as string));
               break;
             case "PlayEffect":
-              styles.beam = {
-                color: action.values[0] as string,
-                temporary: action.values[1] === "Temp",
-              };
+              // "None" disables the beam (and clears any beam from an
+              // earlier matching rule via Continue).
+              if (action.values[0] === "None") {
+                styles.beam = undefined;
+              } else {
+                styles.beam = {
+                  color: action.values[0] as string,
+                  temporary: action.values[1] === "Temp",
+                };
+              }
               break;
           }
         }

--- a/src/providers/filterCompletionProvider.ts
+++ b/src/providers/filterCompletionProvider.ts
@@ -1,0 +1,123 @@
+import * as fs from "fs";
+import path from "path";
+import * as vscode from "vscode";
+
+const SOUND_EXTENSIONS = new Set([".mp3", ".wav", ".ogg"]);
+const FILTER_EXTENSIONS = new Set([".filter"]);
+
+type CompletionContextKind = "import" | "sound";
+
+/**
+ * Completes file names inside quoted paths:
+ *  - `Import "..."` suggests sibling `.filter` files.
+ *  - `CustomAlertSound[Optional] "..."` suggests sibling sound files.
+ *
+ * Paths are resolved relative to the current document's directory (and any
+ * sub-path already typed), matching how the game and the rest of the extension
+ * resolve filter/sound files. Directories are offered too and re-trigger
+ * completion so nested folders can be navigated.
+ */
+export class FilterCompletionProvider
+  implements vscode.CompletionItemProvider
+{
+  provideCompletionItems(
+    document: vscode.TextDocument,
+    position: vscode.Position
+  ): vscode.CompletionItem[] {
+    const linePrefix = document
+      .lineAt(position)
+      .text.slice(0, position.character);
+
+    const kind = this.getContextKind(linePrefix);
+    if (!kind) {
+      return [];
+    }
+
+    // The partial path typed inside the still-open quote.
+    const partial = linePrefix.match(/"([^"]*)$/)?.[1] ?? "";
+
+    // Split the partial into the directory already typed and the fragment being
+    // completed, so only the fragment is replaced.
+    const slashIndex = Math.max(
+      partial.lastIndexOf("/"),
+      partial.lastIndexOf("\\")
+    );
+    const dirPart = slashIndex === -1 ? "" : partial.slice(0, slashIndex + 1);
+    const fragment = slashIndex === -1 ? partial : partial.slice(slashIndex + 1);
+
+    // Replace only the fragment after the last slash. An explicit range avoids
+    // odd behaviour from "." and "-" in file names being treated as word breaks.
+    const replaceRange = new vscode.Range(
+      position.line,
+      position.character - fragment.length,
+      position.line,
+      position.character
+    );
+
+    const baseDir = path.dirname(document.uri.fsPath);
+    const listDir = path.isAbsolute(dirPart)
+      ? dirPart
+      : path.join(baseDir, dirPart);
+
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(listDir, { withFileTypes: true });
+    } catch {
+      return [];
+    }
+
+    const allowedExtensions =
+      kind === "import" ? FILTER_EXTENSIONS : SOUND_EXTENSIONS;
+
+    const items: vscode.CompletionItem[] = [];
+    for (const entry of entries) {
+      if (entry.isDirectory()) {
+        const item = new vscode.CompletionItem(
+          entry.name,
+          vscode.CompletionItemKind.Folder
+        );
+        item.insertText = entry.name + "/";
+        item.range = replaceRange;
+        // Re-trigger so the user can keep drilling into folders.
+        item.command = {
+          command: "editor.action.triggerSuggest",
+          title: "Suggest",
+        };
+        items.push(item);
+        continue;
+      }
+
+      if (!entry.isFile()) {
+        continue;
+      }
+      if (!allowedExtensions.has(path.extname(entry.name).toLowerCase())) {
+        continue;
+      }
+
+      const item = new vscode.CompletionItem(
+        entry.name,
+        vscode.CompletionItemKind.File
+      );
+      item.range = replaceRange;
+      items.push(item);
+    }
+
+    return items;
+  }
+
+  private getContextKind(linePrefix: string): CompletionContextKind | null {
+    // Cursor must be inside an unclosed quote on this line.
+    if (!/"[^"]*$/.test(linePrefix)) {
+      return null;
+    }
+    if (/^\s*Import\b/.test(linePrefix)) {
+      return "import";
+    }
+    // CustomAlertSound supports several semicolon-separated quoted files, so it
+    // is enough that we are inside an open quote on such a line.
+    if (/^\s*(CustomAlertSound|CustomAlertSoundOptional)\b/.test(linePrefix)) {
+      return "sound";
+    }
+    return null;
+  }
+}

--- a/src/providers/filterDocumentLinkProvider.ts
+++ b/src/providers/filterDocumentLinkProvider.ts
@@ -1,0 +1,46 @@
+import path from "path";
+import * as vscode from "vscode";
+
+/**
+ * Turns the file path in an `Import "file.filter"` statement (with or without
+ * the trailing `Optional`) into a clickable link that opens the referenced
+ * filter. Paths are resolved relative to the directory of the current document,
+ * matching how the game loads imported filters.
+ */
+export class FilterDocumentLinkProvider
+  implements vscode.DocumentLinkProvider
+{
+  provideDocumentLinks(document: vscode.TextDocument): vscode.DocumentLink[] {
+    const links: vscode.DocumentLink[] = [];
+    const baseDir = path.dirname(document.uri.fsPath);
+
+    for (let i = 0; i < document.lineCount; i++) {
+      const line = document.lineAt(i);
+
+      // Ignore anything after a comment so commented-out imports aren't linked.
+      const commentIndex = line.text.indexOf("#");
+      const code =
+        commentIndex === -1 ? line.text : line.text.slice(0, commentIndex);
+
+      const match = code.match(/^\s*Import\s+"([^"]+)"/i);
+      if (!match) {
+        continue;
+      }
+
+      const filePath = match[1];
+      // Range covering the path inside the quotes.
+      const startCol = code.indexOf(`"${filePath}"`) + 1;
+      const range = new vscode.Range(i, startCol, i, startCol + filePath.length);
+
+      const targetPath = path.isAbsolute(filePath)
+        ? filePath
+        : path.join(baseDir, filePath);
+
+      const link = new vscode.DocumentLink(range, vscode.Uri.file(targetPath));
+      link.tooltip = "Open imported filter";
+      links.push(link);
+    }
+
+    return links;
+  }
+}

--- a/syntaxes/poe2filter.tmLanguage.json
+++ b/syntaxes/poe2filter.tmLanguage.json
@@ -7,6 +7,9 @@
       "include": "#comments"
     },
     {
+      "include": "#imports"
+    },
+    {
       "include": "#blocks"
     },
     {
@@ -44,6 +47,32 @@
         {
           "name": "keyword.control.poe2filter",
           "match": "\\bContinue\\b"
+        }
+      ]
+    },
+    "imports": {
+      "patterns": [
+        {
+          "begin": "\\b(Import)\\b",
+          "beginCaptures": {
+            "1": { "name": "keyword.control.import.poe2filter" }
+          },
+          "end": "(?=$|#)",
+          "patterns": [
+            {
+              "match": "(\"[^\"]+\")\\s+(Optional)\\b",
+              "captures": {
+                "1": { "name": "string.quoted.double.poe2filter" },
+                "2": { "name": "keyword.control.poe2filter" }
+              }
+            },
+            {
+              "match": "(\"[^\"]+\")",
+              "captures": {
+                "1": { "name": "string.quoted.double.poe2filter" }
+              }
+            }
+          ]
         }
       ]
     },
@@ -181,6 +210,12 @@
                 "2": { "name": "variable.parameter.color.poe2filter" },
                 "3": { "name": "variable.parameter.shape.poe2filter" }
               }
+            },
+            {
+              "match": "(-1)\\b",
+              "captures": {
+                "1": { "name": "constant.numeric.size.poe2filter" }
+              }
             }
           ]
         },
@@ -204,6 +239,12 @@
                 "1": { "name": "constant.language.named-sound-id.poe2filter" },
                 "2": { "name": "constant.numeric.volume.poe2filter" }
               }
+            },
+            {
+              "match": "\\b(None)\\b",
+              "captures": {
+                "1": { "name": "constant.language.poe2filter" }
+              }
             }
           ]
         },
@@ -225,6 +266,12 @@
               "match": "\"([^\"]+)\"",
               "captures": {
                 "1": { "name": "string.quoted.double.sound-file.poe2filter" }
+              }
+            },
+            {
+              "match": "\\b(None)\\b",
+              "captures": {
+                "1": { "name": "constant.language.poe2filter" }
               }
             }
           ]
@@ -248,6 +295,12 @@
               "captures": {
                 "1": { "name": "variable.parameter.color.poe2filter" }
               }
+            },
+            {
+              "match": "\\b(None)\\b",
+              "captures": {
+                "1": { "name": "constant.language.poe2filter" }
+              }
             }
           ]
         },
@@ -267,7 +320,7 @@
           ]
         },
         {
-          "match": "\\b(DisableDropSound|EnableDropSound)\\b",
+          "match": "\\b(DisableDropSoundIfAlertSound|EnableDropSoundIfAlertSound|DisableDropSound|EnableDropSound)\\b",
           "name": "storage.type.sound.poe2filter"
         }
       ]


### PR DESCRIPTION
## Summary
- **`Import`**: `Import "file.filter"` and `Import "file.filter" Optional` (grammar + diagnostics).
- **Import navigation**: the path is a clickable `DocumentLink` (Ctrl/Cmd+Click opens the file), resolved relative to the current document.
- **Import validation**: a non-`Optional` import pointing at a missing file raises a warning (suggests adding `Optional`).
- **File-name completion**: inside `Import "…"` (suggests `.filter` files) and `CustomAlertSound`/`CustomAlertSoundOptional` (suggests `.mp3`/`.wav`/`.ogg`), including the semicolon-separated multi-sound form; folders re-trigger for nested navigation.
- **Disabled / None values**: `MinimapIcon -1`, `PlayEffect None`, `PlayAlertSound None`, `CustomAlertSound None` (preview clears the beam on `PlayEffect None`).
- **Sounds**: semicolon-separated `CustomAlertSound "a";"b" 300` (each path validated).
- **Drop sound**: `DisableDropSoundIfAlertSound` / `EnableDropSoundIfAlertSound`.

## Verification
The semicolon multi-sound form and `DisableDropSound` appear in real PoE2 filters; `Import` is confirmed added in PoE2 v0.3.0 (wiki changelog). The `None`/`-1` disable values and `IfAlertSound` variants are from the official filter docs and need in-game confirmation — `examples/actions-and-keywords.filter` includes a checklist.

## Related
- #9 — introduces the first `CompletionItemProvider` (file-path completion). Block/condition/value/action completion remains open.

Made with [Cursor](https://cursor.com)