### PR TITLE
fix: 🔧 drop vscode:prepublish to silence vsce npm warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -358,10 +358,13 @@ This project uses [release-please](https://github.com/googleapis/release-please)
 
 ```bash
 pnpm install
-pnpm package
+pnpm run build
+pnpm run package
 ```
 
-`pnpm package` runs `vsce package --no-dependencies` and produces `poe2-filter.vsix`, which you can install locally via the Extensions view ("Install from VSIX...").
+Run `build` before `package` — `vsce` invokes npm for `vscode:prepublish`, which is awkward in a pnpm project and triggers noisy npm config warnings. CI and the publish scripts already build first.
+
+`pnpm run package` runs `vsce package --no-dependencies` and produces `poe2-filter.vsix`, which you can install locally via the Extensions view ("Install from VSIX...").
 
 ### Publishing
 

--- a/package.json
+++ b/package.json
@@ -143,7 +143,6 @@
     }
   },
   "scripts": {
-    "vscode:prepublish": "pnpm run build",
     "compile": "pnpm run check-types && pnpm run lint && node esbuild.js",
     "watch": "npm-run-all -p watch:*",
     "watch:esbuild": "node esbuild.js --watch",


### PR DESCRIPTION
## Summary
- Remove `vscode:prepublish` so `vsce package` no longer spawns npm (and the pnpm/npm config warnings that came with it)
- Document that `pnpm run build` must run before `pnpm run package`

## Test plan
- [x] `pnpm run package` completes without npm warnings
- [ ] CI build-and-test still passes (workflows already run `build` before `package`)


Made with [Cursor](https://cursor.com)